### PR TITLE
PBKD: Supply the password as a ReadOnlySpan<byte> as well.

### DIFF
--- a/src/Experimental/PasswordBased/PasswordBasedKeyDerivationAlgorithm.cs
+++ b/src/Experimental/PasswordBased/PasswordBasedKeyDerivationAlgorithm.cs
@@ -95,6 +95,15 @@ namespace NSec.Experimental.PasswordBased
             ReadOnlySpan<byte> salt,
             Span<byte> bytes)
         {
+
+            DeriveBytes(MemoryMarshal.AsBytes(password.AsSpan()), salt, bytes);
+        }
+
+        public void DeriveBytes(
+            ReadOnlySpan<byte> password,
+            ReadOnlySpan<byte> salt,
+            Span<byte> bytes)
+        {
             if (password == null)
                 throw Error.ArgumentNull_Password(nameof(password));
             if (salt.Length != SaltSize)
@@ -104,14 +113,14 @@ namespace NSec.Experimental.PasswordBased
             if (bytes.IsEmpty)
                 return;
 
-            if (!TryDeriveBytesCore(MemoryMarshal.AsBytes(password.AsSpan()), salt, bytes))
+            if (!TryDeriveBytesCore(password, salt, bytes))
             {
                 throw null; // TODO
             }
         }
 
         public Key DeriveKey(
-            string password,
+            ReadOnlySpan<byte> password,
             ReadOnlySpan<byte> salt,
             Algorithm algorithm,
             in KeyCreationParameters creationParameters = default)
@@ -138,7 +147,7 @@ namespace NSec.Experimental.PasswordBased
                 Span<byte> seed = stackalloc byte[seedSize];
                 try
                 {
-                    if (!TryDeriveBytesCore(MemoryMarshal.AsBytes(password.AsSpan()), salt, seed))
+                    if (!TryDeriveBytesCore(password, salt, seed))
                     {
                         throw null; // TODO
                     }
@@ -159,6 +168,15 @@ namespace NSec.Experimental.PasswordBased
             }
 
             return new Key(algorithm, in creationParameters, memory, owner, publicKey);
+        }
+
+        public Key DeriveKey(
+            string password,
+            ReadOnlySpan<byte> salt,
+            Algorithm algorithm,
+            in KeyCreationParameters creationParameters = default)
+        {
+            return DeriveKey(MemoryMarshal.AsBytes(password.AsSpan()), salt, algorithm, creationParameters);
         }
 
         internal sealed override int GetKeySize()

--- a/tests/Base/PasswordHashAlgorithmTests.cs
+++ b/tests/Base/PasswordHashAlgorithmTests.cs
@@ -81,7 +81,14 @@ namespace NSec.Tests.Base
         [MemberData(nameof(PasswordHashAlgorithms))]
         public static void DeriveBytesWithSpanWithNullPassword(PasswordBasedKeyDerivationAlgorithm a)
         {
-            Assert.Throws<ArgumentNullException>("password", () => a.DeriveBytes(null, ReadOnlySpan<byte>.Empty, Span<byte>.Empty));
+            Assert.Throws<ArgumentNullException>("password", () => a.DeriveBytes((string)null, ReadOnlySpan<byte>.Empty, Span<byte>.Empty));
+        }
+
+        [Theory]
+        [MemberData(nameof(PasswordHashAlgorithms))]
+        public static void DeriveBytesWithSpanWithNullPasswordSpan(PasswordBasedKeyDerivationAlgorithm a)
+        {
+            Assert.Throws<ArgumentNullException>("password", () => a.DeriveBytes(ReadOnlySpan<byte>.Empty, ReadOnlySpan<byte>.Empty, Span<byte>.Empty));
         }
 
         [Theory]
@@ -127,7 +134,14 @@ namespace NSec.Tests.Base
         [MemberData(nameof(PasswordHashAlgorithms))]
         public static void DeriveKeyWithNullPassword(PasswordBasedKeyDerivationAlgorithm a)
         {
-            Assert.Throws<ArgumentNullException>("password", () => a.DeriveKey(null, ReadOnlySpan<byte>.Empty, null));
+            Assert.Throws<ArgumentNullException>("password", () => a.DeriveKey((string)null, ReadOnlySpan<byte>.Empty, null));
+        }
+
+        [Theory]
+        [MemberData(nameof(PasswordHashAlgorithms))]
+        public static void DeriveKeyWithNullPasswordSpan(PasswordBasedKeyDerivationAlgorithm a)
+        {
+            Assert.Throws<ArgumentNullException>("password", () => a.DeriveKey(ReadOnlySpan<byte>.Empty, ReadOnlySpan<byte>.Empty, null));
         }
 
         [Theory]


### PR DESCRIPTION
Hello !

First, many thanks for bringing that .NET bindings using `Span<T>` API, which makes cryptography with managed languages more secure!

This PR is about giving the possibility to the developers to supply the password to the PBKD algorithm using a `ReadOnlySpan<byte>` buffer and not only a string, as the latter is persisted in the Strings Pool. This does not involve in huge modifications, as the library is already relying on `ReadOnlySpan<byte>` underneath.

I have written two additional unit tests that verify that an exception is correctly raised when supplying an empty buffer.

Don't hesitate to tell me if something is not good state for being merged to the project.

ZenLulz