### PR TITLE
Added possibility to create key with specified speed

### DIFF
--- a/docs/api/nsec.cryptography.key.md
+++ b/docs/api/nsec.cryptography.key.md
@@ -156,6 +156,50 @@ This method is a shortcut for
 KeyCreationParameters)|RandomGenerator Class#GenerateKey(Algorithm, in
 KeyCreationParameters)]].
 
+### Create(Algorithm, Span<byte>, in KeyCreationParameters)
+
+Creates a new instance of the [[Key|Key Class]] class with a key generated with the given seed.
+
+    Span<byte> mySeed = // [...]
+    public static Key Create(
+        Algorithm algorithm,
+        mySeed,
+        in KeyCreationParameters creationParameters = default)
+
+#### Parameters
+
+algorithm
+: The algorithm for the key.
+
+seed
+: The seed for the key.
+
+creationParameters
+: A [[KeyCreationParameters|KeyCreationParameters Struct]] value that specifies
+    advanced parameters for the creation of the [[Key|Key Class]] instance.
+
+#### Return Value
+
+A new instance of the [[Key|Key Class]] class that represents the new key.
+
+#### Exceptions
+
+ArgumentNullException
+: `algorithm` is `null`.
+
+ArgumentException
+: The seed length does not match the required length.
+
+NotSupportedException
+: The specified algorithm does not use keys.
+
+#### Remarks
+
+This method is a shortcut for
+[[RandomGenerator.Default.GenerateKey(Algorithm, Span<byte>, in
+KeyCreationParameters)|RandomGenerator Class#GenerateKey(Algorithm, Span<byte>, in
+KeyCreationParameters)]].
+
 
 ### Import(Algorithm, ReadOnlySpan<byte>, KeyBlobFormat, in KeyCreationParameters)
 

--- a/docs/api/nsec.cryptography.signaturealgorithm.md
+++ b/docs/api/nsec.cryptography.signaturealgorithm.md
@@ -61,6 +61,17 @@ Gets the size of a signature.
 The signature size, in bytes.
 
 
+### SeedSize
+
+Gets the size of a seed.
+
+    public int SeedSize { get; }
+
+#### Property Value
+
+The seed size, in bytes.
+
+
 ## Methods
 
 

--- a/src/Cryptography/Error.cs
+++ b/src/Cryptography/Error.cs
@@ -189,6 +189,13 @@ namespace NSec.Cryptography
             return new ArgumentException(ResourceManager.GetString(nameof(Argument_SaltNotSupported)), paramName);
         }
 
+        internal static ArgumentException Argument_SeedLength(
+            string paramName,
+            object? arg0)
+        {
+            return new ArgumentException(string.Format(ResourceManager.GetString(nameof(Argument_SeedLength))!, arg0), paramName);
+        }
+
         internal static ArgumentException Argument_SharedSecretLength(
             string paramName,
             object? arg0)

--- a/src/Cryptography/Error.resx
+++ b/src/Cryptography/Error.resx
@@ -243,6 +243,9 @@
   <data name="Argument_SaltNotSupported" xml:space="preserve">
     <value>A salt is not supported by this algorithm and must be an empty span.</value>
   </data>
+  <data name="Argument_SeedLength" xml:space="preserve">
+    <value>The seed must have a length of '{0}' bytes.</value>
+  </data>
   <data name="Argument_SharedSecretLength" xml:space="preserve">
     <value>The length of the shared secret must be less than or equal to {0}.</value>
   </data>

--- a/src/Cryptography/Key.cs
+++ b/src/Cryptography/Key.cs
@@ -107,6 +107,14 @@ namespace NSec.Cryptography
             return RandomGenerator.Default.GenerateKey(algorithm, in creationParameters);
         }
 
+        public static Key Create(
+            Algorithm algorithm,
+            Span<byte> seed,
+            in KeyCreationParameters creationParameters = default)
+        {
+            return RandomGenerator.Default.GenerateKey(algorithm, seed, in creationParameters);
+        }
+
         public static Key Import(
            Algorithm algorithm,
            ReadOnlySpan<byte> blob,

--- a/src/Cryptography/SignatureAlgorithm.cs
+++ b/src/Cryptography/SignatureAlgorithm.cs
@@ -59,6 +59,8 @@ namespace NSec.Cryptography
 
         public int SignatureSize => _signatureSize;
 
+        public int SeedSize => GetSeedSize();
+
         public byte[] Sign(
             Key key,
             ReadOnlySpan<byte> data)

--- a/tests/Core/KeyTests.cs
+++ b/tests/Core/KeyTests.cs
@@ -98,6 +98,7 @@ namespace NSec.Tests.Core
         public static void CreateWithNullAlgorithm()
         {
             Assert.Throws<ArgumentNullException>("algorithm", () => Key.Create(null!));
+            Assert.Throws<ArgumentNullException>("algorithm", () => Key.Create(null!, stackalloc byte[0]));
         }
 
         [Theory]


### PR DESCRIPTION
Currently, `Key.Create()` does not allow to specify a seed for key creation. Normally you want to have a random seed generated when creating a key. However, there are scenarios where you want to generate a key based on a known secret, e.g. when implementing a zero knowledge proof system.

If you are able to specify a seed for secret key generation you can use a signature algorithm to create a private and public key based on a known value (like a salted password hash) which allows to recreate the same key without the need to save it somewhere.

I added an overload `Key.Create(Algorithm, Span<byte>, in KeyCreationParameters)` that allows to specify a seed for key generation. It checks whether the seed size matches the needed length and uses the existing key generation functionality. To be able to get the needed seed size, I added the property `SeedSize` to `SignatureAlgorithm`.