### PR TITLE
Provide a more detailed information why the init of libsodium failed

### DIFF
--- a/src/Cryptography/Error.cs
+++ b/src/Cryptography/Error.cs
@@ -340,6 +340,10 @@ namespace NSec.Cryptography
         {
             return new InvalidOperationException(ResourceManager.GetString(nameof(InvalidOperation_InitializationFailed)));
         }
+        internal static InvalidOperationException InvalidOperation_InitializationFailed_InvalidLibSodiumVersion(string expected, string provided)
+        {
+            return new InvalidOperationException(string.Format(ResourceManager.GetString(nameof(InvalidOperation_InitializationFailed_InvalidLibSodiumVersion))!, expected, provided));
+        }
 
         internal static InvalidOperationException InvalidOperation_InternalError()
         {

--- a/src/Cryptography/Error.resx
+++ b/src/Cryptography/Error.resx
@@ -270,6 +270,9 @@
   <data name="InvalidOperation_InitializationFailed" xml:space="preserve">
     <value>An error occurred while initializing cryptographic primitives.</value>
   </data>
+  <data name="InvalidOperation_InitializationFailed_InvalidLibSodiumVersion" xml:space="preserve">
+    <value>Could not initialize, libsodium version provided is invalid! (Expected: {0} | Provided {1})</value>
+  </data>
   <data name="InvalidOperation_InternalError" xml:space="preserve">
     <value>An internal error occurred.</value>
   </data>

--- a/src/Cryptography/Sodium.cs
+++ b/src/Cryptography/Sodium.cs
@@ -31,7 +31,7 @@ namespace NSec.Cryptography
                 if (sodium_library_version_major() != SODIUM_LIBRARY_VERSION_MAJOR ||
                     sodium_library_version_minor() != SODIUM_LIBRARY_VERSION_MINOR)
                 {
-                    throw Error.InvalidOperation_InitializationFailed();
+                    throw Error.InvalidOperation_InitializationFailed_InvalidLibSodiumVersion($"{SODIUM_LIBRARY_VERSION_MAJOR}.{SODIUM_LIBRARY_VERSION_MINOR}", $"{sodium_library_version_major()}.{sodium_library_version_minor()}");
                 }
 
                 if (sodium_set_misuse_handler(s_misuseHandler) != 0)


### PR DESCRIPTION
I also use libsodium on linux-arm, the prebuilt libsodium nuget package does not provide linux-arm, therefore I have to built it on my own. After upgrading nsec, the libsodium lib was not the correct one anymore, so I needed to check the code why. With the correct error message I would have figured it out immediately.