### PR TITLE
added export to shared secret

### DIFF
--- a/src/Cryptography/NSec.Cryptography.csproj
+++ b/src/Cryptography/NSec.Cryptography.csproj
@@ -20,7 +20,7 @@ NSec.Cryptography.X25519</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="libsodium" Version="[1.0.18,1.0.19)" />
+    <PackageReference Include="libsodium" Version="1.0.18.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">

--- a/src/Cryptography/SharedSecret.cs
+++ b/src/Cryptography/SharedSecret.cs
@@ -5,21 +5,39 @@ using static Interop.Libsodium;
 
 namespace NSec.Cryptography
 {
+    /// <summary>
+    /// represents a shared secret
+    /// </summary>
     [DebuggerDisplay("Size = {Size}")]
     public sealed class SharedSecret : IDisposable
     {
+        /// <summary>
+        /// handle to the underlying secure memory structure
+        /// </summary>
         private readonly SecureMemoryHandle _handle;
-
+        /// <summary>
+        /// ctor using a provided handle
+        /// </summary>
+        /// <param name="sharedSecretHandle"></param>
         internal SharedSecret(
             SecureMemoryHandle sharedSecretHandle)
         {
             _handle = sharedSecretHandle;
         }
-
+        /// <summary>
+        /// length of the key
+        /// </summary>
         public int Size => _handle.Size;
-
+        /// <summary>
+        /// internally exposed handle
+        /// </summary>
         internal SecureMemoryHandle Handle => _handle;
-
+        /// <summary>
+        /// imports a shared key
+        /// </summary>
+        /// <param name="sharedSecret"></param>
+        /// <param name="creationParameters"></param>
+        /// <returns></returns>
         [Obsolete("The 'Import' method is obsolete. Use the method overloads in the 'KeyDerivationAlgorithm' class that accept a 'ReadOnlySpan<byte>' directly instead.")]
         public static SharedSecret Import(
             ReadOnlySpan<byte> sharedSecret,
@@ -55,18 +73,35 @@ namespace NSec.Cryptography
 
             return new SharedSecret(sharedSecretHandle);
         }
-
+        /// <summary>
+        /// disposes the secret
+        /// </summary>
         public void Dispose()
         {
             _handle.Dispose();
         }
-
+        /// <summary>
+        /// to string
+        /// </summary>
+        /// <returns></returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override string? ToString()
         {
             return typeof(SharedSecret).ToString();
         }
-
+        /// <summary>
+        /// copies secret data to the given destination
+        /// </summary>
+        /// <param name="destination"></param>
+        public void CopyTo(Span<byte> destination)
+        {
+            _handle.CopyTo(destination);
+        }
+        /// <summary>
+        /// creates a new secret via import
+        /// </summary>
+        /// <param name="sharedSecret"></param>
+        /// <param name="sharedSecretHandle"></param>
         private static void ImportCore(
             ReadOnlySpan<byte> sharedSecret,
             out SecureMemoryHandle? sharedSecretHandle)


### PR DESCRIPTION
keeping shared secret locked maybe useful but prevents using keys on features like dotnet internal HKDF. Added an export therefore which basically just calls export on the underlying memory handle.