### PR TITLE
Add back netstandard2.0 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,18 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.x
+    - name: Setup msbuild
+      uses: microsoft/setup-msbuild@v1.1
     - run: dotnet --info
     - name: Test (.NET 6.0/Debug)
       run: dotnet test tests -f net6.0 -c Debug
     - name: Test (.NET 6.0/Release)
       run: dotnet test tests -f net6.0 -c Release
+    - name: Test (.NET 4.x)
+      run: |
+        dotnet restore tests/Tests.csproj
+        msbuild tests/Tests.csproj /p:Configuration=Release
+        dotnet test tests -f net48 -c Release --no-build --no-restore
     - name: Pack
       run: dotnet pack -c Release
     - name: Upload artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 bin
 obj
 public/
+/.idea

--- a/NOTICE
+++ b/NOTICE
@@ -133,3 +133,30 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+License Notice for Hex and Base64 Implementation
+------------------------------------------------
+
+This software contains code derived from Bradley Grainger's IndexRange
+implementation, which is available under the MIT license.
+
+Copyright (c) 2019–2022 Bradley Grainger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/Cryptography/Formatting/PrivateKeyFormatter.cs
+++ b/src/Cryptography/Formatting/PrivateKeyFormatter.cs
@@ -82,7 +82,7 @@ namespace NSec.Cryptography.Formatting
             }
             finally
             {
-                System.Security.Cryptography.CryptographicOperations.ZeroMemory(temp);
+                FrameworkHelpers.ZeroMemory(temp);
             }
         }
 
@@ -121,7 +121,7 @@ namespace NSec.Cryptography.Formatting
             }
             finally
             {
-                System.Security.Cryptography.CryptographicOperations.ZeroMemory(temp);
+                FrameworkHelpers.ZeroMemory(temp);
             }
         }
 

--- a/src/Cryptography/FrameworkHelpers.cs
+++ b/src/Cryptography/FrameworkHelpers.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace NSec.Cryptography
+{
+    internal static class FrameworkHelpers
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool FixedTimeEquals(ReadOnlySpan<byte> left, ReadOnlySpan<byte> right)
+        {
+#if NETSTANDARD2_0
+            return FixedTimeEqualsImpl(left, right);
+#else
+            return System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(left, right);
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+        private static bool FixedTimeEqualsImpl(ReadOnlySpan<byte> left, ReadOnlySpan<byte> right)
+        {
+            // NoOptimization because we want this method to be exactly as non-short-circuiting
+            // as written.
+            //
+            // NoInlining because the NoOptimization would get lost if the method got inlined.
+
+            if (left.Length != right.Length)
+            {
+                return false;
+            }
+
+            int length = left.Length;
+            int accum = 0;
+
+            for (int i = 0; i < length; i++)
+            {
+                accum |= left[i] - right[i];
+            }
+
+            return accum == 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ZeroMemory(Span<byte> buffer)
+        {
+#if NETSTANDARD2_0
+            ZeroMemoryImpl(buffer);
+#else
+            System.Security.Cryptography.CryptographicOperations.ZeroMemory(buffer);
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+        private static void ZeroMemoryImpl(Span<byte> buffer)
+        {
+            // NoOptimize to prevent the optimizer from deciding this call is unnecessary
+            // NoInlining to prevent the inliner from forgetting that the method was no-optimize
+            buffer.Clear();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void Fill(Span<byte> seed)
+        {
+#if NETSTANDARD2_0
+            unsafe
+            {
+                fixed (byte* buf = seed)
+                {
+                    Interop.Libsodium.randombytes_buf(buf, (nuint)seed.Length);
+                }
+            }
+#else
+            System.Security.Cryptography.RandomNumberGenerator.Fill(seed);
+#endif
+        }
+    }
+}

--- a/src/Cryptography/HashAlgorithm.cs
+++ b/src/Cryptography/HashAlgorithm.cs
@@ -137,7 +137,7 @@ namespace NSec.Cryptography
         {
             Span<byte> temp = stackalloc byte[_hashSize];
             HashCore(data, temp);
-            return System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(temp, hash);
+            return FrameworkHelpers.FixedTimeEquals(temp, hash);
         }
 
         internal abstract void FinalizeCore(

--- a/src/Cryptography/HkdfSha512.cs
+++ b/src/Cryptography/HkdfSha512.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using static Interop.Libsodium;
 
 namespace NSec.Cryptography
@@ -34,13 +37,21 @@ namespace NSec.Cryptography
     //
     public sealed class HkdfSha512 : KeyDerivationAlgorithm2
     {
+        private static int s_selfTest;
+
         public HkdfSha512() : base(
             supportsSalt: true,
             maxCount: byte.MaxValue * crypto_auth_hmacsha512_BYTES,
             pseudorandomKeySize: crypto_auth_hmacsha512_BYTES)
         {
+            if (s_selfTest == 0)
+            {
+                SelfTest();
+                Interlocked.Exchange(ref s_selfTest, 1);
+            }
         }
 
+#if NET5_0_OR_GREATER
         private protected override void DeriveBytesCore(
             ReadOnlySpan<byte> inputKeyingMaterial,
             ReadOnlySpan<byte> salt,
@@ -77,6 +88,111 @@ namespace NSec.Cryptography
                 inputKeyingMaterial,
                 salt,
                 pseudorandomKey);
+        }
+#else
+        private protected override unsafe void ExpandCore(
+            ReadOnlySpan<byte> pseudorandomKey,
+            ReadOnlySpan<byte> info,
+            Span<byte> bytes)
+        {
+            Debug.Assert(pseudorandomKey.Length >= crypto_auth_hmacsha512_BYTES);
+            Debug.Assert(bytes.Length <= byte.MaxValue * crypto_auth_hmacsha512_BYTES);
+
+            byte* temp = stackalloc byte[crypto_auth_hmacsha512_BYTES];
+
+            try
+            {
+                fixed (byte* key = pseudorandomKey)
+                fixed (byte* @in = info)
+                fixed (byte* @out = bytes)
+                {
+                    int tempLength = 0;
+                    int offset = 0;
+                    byte counter = 0;
+                    int chunkSize;
+
+                    crypto_auth_hmacsha512_state initialState;
+                    crypto_auth_hmacsha512_init(&initialState, key, (nuint)pseudorandomKey.Length);
+
+                    while ((chunkSize = bytes.Length - offset) > 0)
+                    {
+                        counter++;
+
+                        crypto_auth_hmacsha512_state state = initialState;
+                        crypto_auth_hmacsha512_update(&state, temp, (ulong)tempLength);
+                        crypto_auth_hmacsha512_update(&state, @in, (ulong)info.Length);
+                        crypto_auth_hmacsha512_update(&state, &counter, sizeof(byte));
+                        crypto_auth_hmacsha512_final(&state, temp);
+
+                        tempLength = crypto_auth_hmacsha512_BYTES;
+
+                        if (chunkSize > crypto_auth_hmacsha512_BYTES)
+                        {
+                            chunkSize = crypto_auth_hmacsha512_BYTES;
+                        }
+
+                        Unsafe.CopyBlockUnaligned(@out + offset, temp, (uint)chunkSize);
+                        offset += chunkSize;
+                    }
+                }
+            }
+            finally
+            {
+                Unsafe.InitBlockUnaligned(temp, 0, crypto_auth_hmacsha512_BYTES);
+            }
+        }
+
+        private protected override unsafe void ExtractCore(
+            ReadOnlySpan<byte> inputKeyingMaterial,
+            ReadOnlySpan<byte> salt,
+            Span<byte> pseudorandomKey)
+        {
+            Debug.Assert(pseudorandomKey.Length == crypto_auth_hmacsha512_BYTES);
+
+            // According to RFC 5869, the salt must be set to a string of
+            // HashLen zeros if not provided. A ReadOnlySpan<byte> cannot be
+            // "not provided", so this is not implemented.
+
+            fixed (byte* ikm = inputKeyingMaterial)
+            fixed (byte* key = salt)
+            fixed (byte* @out = pseudorandomKey)
+            {
+                crypto_auth_hmacsha512_state state;
+                crypto_auth_hmacsha512_init(&state, key, (nuint)salt.Length);
+                crypto_auth_hmacsha512_update(&state, ikm, (ulong)inputKeyingMaterial.Length);
+                crypto_auth_hmacsha512_final(&state, @out);
+            }
+        }
+
+        private protected override unsafe void ExtractCore(
+            SecureMemoryHandle sharedSecretHandle,
+            ReadOnlySpan<byte> salt,
+            Span<byte> pseudorandomKey)
+        {
+            Debug.Assert(pseudorandomKey.Length == crypto_auth_hmacsha512_BYTES);
+
+            // According to RFC 5869, the salt must be set to a string of
+            // HashLen zeros if not provided. A ReadOnlySpan<byte> cannot be
+            // "not provided", so this is not implemented.
+
+            fixed (byte* key = salt)
+            fixed (byte* @out = pseudorandomKey)
+            {
+                crypto_auth_hmacsha512_state state;
+                crypto_auth_hmacsha512_init(&state, key, (nuint)salt.Length);
+                crypto_auth_hmacsha512_update(&state, sharedSecretHandle, (ulong)sharedSecretHandle.Size);
+                crypto_auth_hmacsha512_final(&state, @out);
+            }
+        }
+#endif
+
+        private static void SelfTest()
+        {
+            if ((crypto_auth_hmacsha512_bytes() != crypto_auth_hmacsha512_BYTES) ||
+                (crypto_auth_hmacsha512_statebytes() != (nuint)Unsafe.SizeOf<crypto_auth_hmacsha512_state>()))
+            {
+                throw Error.InvalidOperation_InitializationFailed();
+            }
         }
     }
 }

--- a/src/Cryptography/IncrementalHash.cs
+++ b/src/Cryptography/IncrementalHash.cs
@@ -78,7 +78,7 @@ namespace NSec.Cryptography
             {
                 Span<byte> temp = stackalloc byte[state._algorithm.HashSize];
                 state._algorithm.FinalizeCore(ref Unsafe.AsRef(in state._state), temp);
-                return System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(temp, hash);
+                return FrameworkHelpers.FixedTimeEquals(temp, hash);
             }
             finally
             {

--- a/src/Cryptography/IncrementalMac.cs
+++ b/src/Cryptography/IncrementalMac.cs
@@ -78,7 +78,7 @@ namespace NSec.Cryptography
             {
                 Span<byte> temp = stackalloc byte[state._algorithm.MacSize];
                 state._algorithm.FinalizeCore(ref Unsafe.AsRef(in state._state), temp);
-                return System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(temp, mac);
+                return FrameworkHelpers.FixedTimeEquals(temp, mac);
             }
             finally
             {

--- a/src/Cryptography/Key.cs
+++ b/src/Cryptography/Key.cs
@@ -36,13 +36,13 @@ namespace NSec.Cryptography
                 Span<byte> seed = stackalloc byte[seedSize];
                 try
                 {
-                    System.Security.Cryptography.RandomNumberGenerator.Fill(seed);
+                    FrameworkHelpers.Fill(seed);
                     algorithm.CreateKey(seed, out keyHandle, out publicKey);
                     success = true;
                 }
                 finally
                 {
-                    System.Security.Cryptography.CryptographicOperations.ZeroMemory(seed);
+                    FrameworkHelpers.ZeroMemory(seed);
                 }
             }
             finally

--- a/src/Cryptography/KeyDerivationAlgorithm.cs
+++ b/src/Cryptography/KeyDerivationAlgorithm.cs
@@ -180,7 +180,7 @@ namespace NSec.Cryptography
                 }
                 finally
                 {
-                    System.Security.Cryptography.CryptographicOperations.ZeroMemory(seed);
+                    FrameworkHelpers.ZeroMemory(seed);
                 }
             }
             finally
@@ -302,7 +302,7 @@ namespace NSec.Cryptography
                 }
                 finally
                 {
-                    System.Security.Cryptography.CryptographicOperations.ZeroMemory(seed);
+                    FrameworkHelpers.ZeroMemory(seed);
                 }
             }
             finally

--- a/src/Cryptography/KeyDerivationAlgorithm2.cs
+++ b/src/Cryptography/KeyDerivationAlgorithm2.cs
@@ -195,7 +195,7 @@ namespace NSec.Cryptography
                 }
                 finally
                 {
-                    System.Security.Cryptography.CryptographicOperations.ZeroMemory(seed);
+                    FrameworkHelpers.ZeroMemory(seed);
                 }
             }
             finally
@@ -226,7 +226,7 @@ namespace NSec.Cryptography
             }
             finally
             {
-                System.Security.Cryptography.CryptographicOperations.ZeroMemory(pseudorandomKey);
+                FrameworkHelpers.ZeroMemory(pseudorandomKey);
             }
         }
 

--- a/src/Cryptography/MacAlgorithm.cs
+++ b/src/Cryptography/MacAlgorithm.cs
@@ -202,7 +202,7 @@ namespace NSec.Cryptography
 
             Span<byte> temp = stackalloc byte[_macSize];
             MacCore(key.Handle, data, temp);
-            return System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(temp, mac);
+            return FrameworkHelpers.FixedTimeEquals(temp, mac);
         }
 
         internal abstract void FinalizeCore(

--- a/src/Cryptography/NSec.Cryptography.csproj.orig
+++ b/src/Cryptography/NSec.Cryptography.csproj.orig
@@ -1,7 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+<<<<<<< HEAD
+    <TargetFramework>net6.0</TargetFramework>
+=======
+    <TargetFrameworks>net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+>>>>>>> f540a7c (Add back netstandard2.0 support)
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Cryptography/PasswordBasedKeyDerivationAlgorithm.cs
+++ b/src/Cryptography/PasswordBasedKeyDerivationAlgorithm.cs
@@ -190,7 +190,7 @@ namespace NSec.Cryptography
                 }
                 finally
                 {
-                    System.Security.Cryptography.CryptographicOperations.ZeroMemory(seed);
+                    FrameworkHelpers.ZeroMemory(seed);
                 }
             }
             finally

--- a/src/Cryptography/RandomGenerator.cs
+++ b/src/Cryptography/RandomGenerator.cs
@@ -128,7 +128,7 @@ namespace NSec.Cryptography
                 }
                 finally
                 {
-                    global::System.Security.Cryptography.CryptographicOperations.ZeroMemory(seed);
+                    FrameworkHelpers.ZeroMemory(seed);
                 }
             }
             finally
@@ -201,13 +201,13 @@ namespace NSec.Cryptography
             private protected unsafe override void GenerateBytesCore(
                 Span<byte> bytes)
             {
-                global::System.Security.Cryptography.RandomNumberGenerator.Fill(bytes);
+                FrameworkHelpers.Fill(bytes);
             }
 
             private protected override uint GenerateUInt32Core()
             {
                 Span<byte> bytes = stackalloc byte[sizeof(uint)];
-                global::System.Security.Cryptography.RandomNumberGenerator.Fill(bytes);
+                FrameworkHelpers.Fill(bytes);
                 return global::System.Buffers.Binary.BinaryPrimitives.ReadUInt32BigEndian(bytes);
             }
         }

--- a/src/Cryptography/SharedSecret.cs
+++ b/src/Cryptography/SharedSecret.cs
@@ -215,9 +215,9 @@ namespace NSec.Cryptography
             }
 
             BinaryPrimitives.WriteUInt32BigEndian(blob, NSecBlobHeader);
-            BinaryPrimitives.WriteInt16LittleEndian(blob[sizeof(uint)..], (short)sharedSecretHandle.Size);
-            BinaryPrimitives.WriteInt16LittleEndian(blob[(sizeof(uint) + sizeof(short))..], 0);
-            sharedSecretHandle.CopyTo(blob[(sizeof(uint) + sizeof(short) + sizeof(short))..]);
+            BinaryPrimitives.WriteInt16LittleEndian(blob.Slice(sizeof(uint)), (short)sharedSecretHandle.Size);
+            BinaryPrimitives.WriteInt16LittleEndian(blob.Slice((sizeof(uint) + sizeof(short))), 0);
+            sharedSecretHandle.CopyTo(blob.Slice((sizeof(uint) + sizeof(short) + sizeof(short))));
             return true;
         }
 
@@ -257,13 +257,13 @@ namespace NSec.Cryptography
             if (blob.Length < sizeof(uint) + sizeof(short) + sizeof(short) ||
                 blob.Length > sizeof(uint) + sizeof(short) + sizeof(short) + MaxSize ||
                 BinaryPrimitives.ReadUInt32BigEndian(blob) != NSecBlobHeader ||
-                BinaryPrimitives.ReadInt16LittleEndian(blob[sizeof(uint)..]) != blob.Length - (sizeof(uint) + sizeof(short) + sizeof(short)))
+                BinaryPrimitives.ReadInt16LittleEndian(blob.Slice(sizeof(uint))) != blob.Length - (sizeof(uint) + sizeof(short) + sizeof(short)))
             {
                 sharedSecretHandle = null;
                 return false;
             }
 
-            sharedSecretHandle = SecureMemoryHandle.CreateFrom(blob[(sizeof(uint) + sizeof(short) + sizeof(short))..]);
+            sharedSecretHandle = SecureMemoryHandle.CreateFrom(blob.Slice((sizeof(uint) + sizeof(short) + sizeof(short))));
             return true;
         }
 

--- a/src/Cryptography/Sodium.cs
+++ b/src/Cryptography/Sodium.cs
@@ -8,6 +8,8 @@ namespace NSec.Cryptography
 {
     internal static class Sodium
     {
+        private static readonly Action s_misuseHandler = new(InternalError);
+
         private static int s_initialized;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -20,7 +22,7 @@ namespace NSec.Cryptography
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static unsafe void InitializeCore()
+        private static void InitializeCore()
         {
             try
             {
@@ -33,7 +35,7 @@ namespace NSec.Cryptography
                         : Error.InvalidOperation_InitializationFailed();
                 }
 
-                if (sodium_set_misuse_handler(&InternalError) != 0)
+                if (sodium_set_misuse_handler(s_misuseHandler) != 0)
                 {
                     throw Error.InvalidOperation_InitializationFailed();
                 }
@@ -57,9 +59,6 @@ namespace NSec.Cryptography
             Interlocked.Exchange(ref s_initialized, 1);
         }
 
-#if !NETSTANDARD2_0
-        [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
-#endif
         private static void InternalError()
         {
             throw Error.InvalidOperation_InternalError();

--- a/src/Cryptography/Sodium.cs
+++ b/src/Cryptography/Sodium.cs
@@ -57,7 +57,9 @@ namespace NSec.Cryptography
             Interlocked.Exchange(ref s_initialized, 1);
         }
 
+#if !NETSTANDARD2_0
         [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+#endif
         private static void InternalError()
         {
             throw Error.InvalidOperation_InternalError();

--- a/src/Experimental/CryptographicUtilities.cs
+++ b/src/Experimental/CryptographicUtilities.cs
@@ -23,7 +23,7 @@ namespace NSec.Experimental
         public static void FillRandomBytes(
             Span<byte> data)
         {
-            System.Security.Cryptography.RandomNumberGenerator.Fill(data);
+            Cryptography.FrameworkHelpers.Fill(data);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -31,7 +31,7 @@ namespace NSec.Experimental
             ReadOnlySpan<byte> left,
             ReadOnlySpan<byte> right)
         {
-            return System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(left, right);
+            return Cryptography.FrameworkHelpers.FixedTimeEquals(left, right);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
@@ -72,7 +72,7 @@ namespace NSec.Experimental
         public static void ZeroMemory(
             Span<byte> buffer)
         {
-            System.Security.Cryptography.CryptographicOperations.ZeroMemory(buffer);
+            Cryptography.FrameworkHelpers.ZeroMemory(buffer);
         }
     }
 }

--- a/src/Experimental/IndexRangePolyfill.cs
+++ b/src/Experimental/IndexRangePolyfill.cs
@@ -1,0 +1,251 @@
+﻿// https://github.com/bgrainger/IndexRange/
+
+#if NETSTANDARD2_0
+
+using System.Runtime.CompilerServices;
+
+namespace System
+{
+    /// <summary>Represent a type can be used to index a collection either from the start or the end.</summary>
+    /// <remarks>
+    /// Index is used by the C# compiler to support the new index syntax
+    /// <code>
+    /// int[] someArray = new int[5] { 1, 2, 3, 4, 5 } ;
+    /// int lastElement = someArray[^1]; // lastElement = 5
+    /// </code>
+    /// </remarks>
+    public readonly struct Index : IEquatable<Index>
+    {
+        private readonly int _value;
+
+        /// <summary>Construct an Index using a value and indicating if the index is from the start or from the end.</summary>
+        /// <param name="value">The index value. it has to be zero or positive number.</param>
+        /// <param name="fromEnd">Indicating if the index is from the start or from the end.</param>
+        /// <remarks>
+        /// If the Index constructed from the end, index value 1 means pointing at the last element and index value 0 means pointing at beyond last element.
+        /// </remarks>
+#if !NET35
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public Index(int value, bool fromEnd = false)
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "value must be non-negative");
+            }
+
+            if (fromEnd)
+                _value = ~value;
+            else
+                _value = value;
+        }
+
+        // The following private constructors mainly created for perf reason to avoid the checks
+        private Index(int value)
+        {
+            _value = value;
+        }
+
+        /// <summary>Create an Index pointing at first element.</summary>
+        public static Index Start => new Index(0);
+
+        /// <summary>Create an Index pointing at beyond last element.</summary>
+        public static Index End => new Index(~0);
+
+        /// <summary>Create an Index from the start at the position indicated by the value.</summary>
+        /// <param name="value">The index value from the start.</param>
+#if !NET35
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static Index FromStart(int value)
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "value must be non-negative");
+            }
+
+            return new Index(value);
+        }
+
+        /// <summary>Create an Index from the end at the position indicated by the value.</summary>
+        /// <param name="value">The index value from the end.</param>
+#if !NET35
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static Index FromEnd(int value)
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "value must be non-negative");
+            }
+
+            return new Index(~value);
+        }
+
+        /// <summary>Returns the index value.</summary>
+        public int Value
+        {
+            get
+            {
+                if (_value < 0)
+                    return ~_value;
+                else
+                    return _value;
+            }
+        }
+
+        /// <summary>Indicates whether the index is from the start or the end.</summary>
+        public bool IsFromEnd => _value < 0;
+
+        /// <summary>Calculate the offset from the start using the giving collection length.</summary>
+        /// <param name="length">The length of the collection that the Index will be used with. length has to be a positive value</param>
+        /// <remarks>
+        /// For performance reason, we don't validate the input length parameter and the returned offset value against negative values.
+        /// we don't validate either the returned offset is greater than the input length.
+        /// It is expected Index will be used with collections which always have non negative length/count. If the returned offset is negative and
+        /// then used to index a collection will get out of range exception which will be same affect as the validation.
+        /// </remarks>
+#if !NET35
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public int GetOffset(int length)
+        {
+            int offset = _value;
+            if (IsFromEnd)
+            {
+                // offset = length - (~value)
+                // offset = length + (~(~value) + 1)
+                // offset = length + value + 1
+
+                offset += length + 1;
+            }
+
+            return offset;
+        }
+
+        /// <summary>Indicates whether the current Index object is equal to another object of the same type.</summary>
+        /// <param name="value">An object to compare with this object</param>
+        public override bool Equals(object? value) => value is Index && _value == ((Index)value)._value;
+
+        /// <summary>Indicates whether the current Index object is equal to another Index object.</summary>
+        /// <param name="other">An object to compare with this object</param>
+        public bool Equals(Index other) => _value == other._value;
+
+        /// <summary>Returns the hash code for this instance.</summary>
+        public override int GetHashCode() => _value;
+
+        /// <summary>Converts integer number to an Index.</summary>
+        public static implicit operator Index(int value) => FromStart(value);
+
+        /// <summary>Converts the value of the current Index object to its equivalent string representation.</summary>
+        public override string ToString()
+        {
+            if (IsFromEnd)
+                return "^" + ((uint)Value).ToString();
+
+            return ((uint)Value).ToString();
+        }
+    }
+
+    /// <summary>Represent a range has start and end indexes.</summary>
+    /// <remarks>
+    /// Range is used by the C# compiler to support the range syntax.
+    /// <code>
+    /// int[] someArray = new int[5] { 1, 2, 3, 4, 5 };
+    /// int[] subArray1 = someArray[0..2]; // { 1, 2 }
+    /// int[] subArray2 = someArray[1..^0]; // { 2, 3, 4, 5 }
+    /// </code>
+    /// </remarks>
+    public readonly struct Range : IEquatable<Range>
+    {
+        /// <summary>Represent the inclusive start index of the Range.</summary>
+        public Index Start
+        {
+            get;
+        }
+
+        /// <summary>Represent the exclusive end index of the Range.</summary>
+        public Index End
+        {
+            get;
+        }
+
+        /// <summary>Construct a Range object using the start and end indexes.</summary>
+        /// <param name="start">Represent the inclusive start index of the range.</param>
+        /// <param name="end">Represent the exclusive end index of the range.</param>
+        public Range(Index start, Index end)
+        {
+            Start = start;
+            End = end;
+        }
+
+        /// <summary>Indicates whether the current Range object is equal to another object of the same type.</summary>
+        /// <param name="value">An object to compare with this object</param>
+        public override bool Equals(object? value) =>
+            value is Range r &&
+            r.Start.Equals(Start) &&
+            r.End.Equals(End);
+
+        /// <summary>Indicates whether the current Range object is equal to another Range object.</summary>
+        /// <param name="other">An object to compare with this object</param>
+        public bool Equals(Range other) => other.Start.Equals(Start) && other.End.Equals(End);
+
+        /// <summary>Returns the hash code for this instance.</summary>
+        public override int GetHashCode()
+        {
+            return Start.GetHashCode() * 31 + End.GetHashCode();
+        }
+
+        /// <summary>Converts the value of the current Range object to its equivalent string representation.</summary>
+        public override string ToString()
+        {
+            return Start + ".." + End;
+        }
+
+        /// <summary>Create a Range object starting from start index to the end of the collection.</summary>
+        public static Range StartAt(Index start) => new Range(start, Index.End);
+
+        /// <summary>Create a Range object starting from first element in the collection to the end Index.</summary>
+        public static Range EndAt(Index end) => new Range(Index.Start, end);
+
+        /// <summary>Create a Range object starting from first element to the end.</summary>
+        public static Range All => new Range(Index.Start, Index.End);
+
+        /// <summary>Calculate the start offset and length of range object using a collection length.</summary>
+        /// <param name="length">The length of the collection that the range will be used with. length has to be a positive value.</param>
+        /// <remarks>
+        /// For performance reason, we don't validate the input length parameter against negative values.
+        /// It is expected Range will be used with collections which always have non negative length/count.
+        /// We validate the range is inside the length scope though.
+        /// </remarks>
+#if !NET35
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        [CLSCompliant(false)]
+        public (int Offset, int Length) GetOffsetAndLength(int length)
+        {
+            int start;
+            Index startIndex = Start;
+            if (startIndex.IsFromEnd)
+                start = length - startIndex.Value;
+            else
+                start = startIndex.Value;
+
+            int end;
+            Index endIndex = End;
+            if (endIndex.IsFromEnd)
+                end = length - endIndex.Value;
+            else
+                end = endIndex.Value;
+
+            if ((uint)end > (uint)length || (uint)start > (uint)end)
+            {
+                throw new ArgumentOutOfRangeException(nameof(length));
+            }
+
+            return (start, end - start);
+        }
+    }
+}
+
+#endif

--- a/src/Experimental/Iso78164Padding.cs
+++ b/src/Experimental/Iso78164Padding.cs
@@ -56,7 +56,7 @@ namespace NSec.Experimental
             }
 
             padded[unpadded.Length] = 0x80;
-            padded[(unpadded.Length + 1)..].Clear();
+            padded.Slice(unpadded.Length + 1).Clear();
         }
 
         public static byte[]? Unpad(
@@ -88,7 +88,7 @@ namespace NSec.Experimental
                     }
                     else if (padded[i] == 0x80)
                     {
-                        result = padded[..i];
+                        result = padded.Slice(0, i);
                         return true;
                     }
                     else

--- a/src/Experimental/KeyConverter.cs
+++ b/src/Experimental/KeyConverter.cs
@@ -54,7 +54,7 @@ namespace NSec.Cryptography
                 }
                 finally
                 {
-                    System.Security.Cryptography.CryptographicOperations.ZeroMemory(seed);
+                    FrameworkHelpers.ZeroMemory(seed);
                 }
             }
             finally

--- a/src/Experimental/NSec.Experimental.csproj
+++ b/src/Experimental/NSec.Experimental.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Experimental/NSec.Experimental.csproj.orig
+++ b/src/Experimental/NSec.Experimental.csproj.orig
@@ -1,7 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+<<<<<<< HEAD
+    <TargetFramework>net6.0</TargetFramework>
+=======
     <TargetFrameworks>net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+>>>>>>> f540a7c (Add back netstandard2.0 support)
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Experimental/PasswordBased/Pbkdf2HmacSha256.cs
+++ b/src/Experimental/PasswordBased/Pbkdf2HmacSha256.cs
@@ -51,13 +51,17 @@ namespace NSec.Experimental.PasswordBased
             ReadOnlySpan<byte> salt,
             Span<byte> bytes)
         {
+#if NETSTANDARD2_0
+            throw new PlatformNotSupportedException();
+#else
+
             System.Security.Cryptography.Rfc2898DeriveBytes.Pbkdf2(
                 password,
                 salt,
                 bytes,
                 _c,
                 System.Security.Cryptography.HashAlgorithmName.SHA256);
-
+#endif
             return true;
         }
     }

--- a/src/Interop/Interop.Auth.HmacSha256.cs
+++ b/src/Interop/Interop.Auth.HmacSha256.cs
@@ -40,6 +40,12 @@ internal static partial class Interop
             byte* @in,
             ulong inlen);
 
+        [DllImport(Libraries.Libsodium, CallingConvention = CallingConvention.Cdecl)]
+        internal static unsafe extern int crypto_auth_hmacsha256_update(
+            crypto_auth_hmacsha256_state* state,
+            SecureMemoryHandle @in,
+            ulong inlen);
+
         [StructLayout(LayoutKind.Explicit, Size = 208)]
         internal struct crypto_auth_hmacsha256_state
         {

--- a/src/Interop/Interop.Auth.HmacSha512.cs
+++ b/src/Interop/Interop.Auth.HmacSha512.cs
@@ -37,6 +37,12 @@ internal static partial class Interop
         [DllImport(Libraries.Libsodium, CallingConvention = CallingConvention.Cdecl)]
         internal static unsafe extern int crypto_auth_hmacsha512_update(
             crypto_auth_hmacsha512_state* state,
+            SecureMemoryHandle @in,
+            ulong inlen);
+
+        [DllImport(Libraries.Libsodium, CallingConvention = CallingConvention.Cdecl)]
+        internal static unsafe extern int crypto_auth_hmacsha512_update(
+            crypto_auth_hmacsha512_state* state,
             byte* @in,
             ulong inlen);
 

--- a/src/Interop/Interop.Core.cs
+++ b/src/Interop/Interop.Core.cs
@@ -9,7 +9,6 @@ internal static partial class Interop
         internal static extern int sodium_init();
 
         [DllImport(Libraries.Libsodium, CallingConvention = CallingConvention.Cdecl)]
-        internal static unsafe extern int sodium_set_misuse_handler(
-            delegate* unmanaged[Cdecl]<void> handler);
+        internal static extern int sodium_set_misuse_handler(Action handler);
     }
 }

--- a/src/Interop/Interop.Random.cs
+++ b/src/Interop/Interop.Random.cs
@@ -1,0 +1,17 @@
+﻿using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Libsodium
+    {
+        [DllImport(Libraries.Libsodium, CallingConvention = CallingConvention.Cdecl)]
+        internal static unsafe extern void randombytes_buf(
+            void* buf,
+            nuint size);
+
+        [DllImport(Libraries.Libsodium, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void randombytes_buf(
+            out uint buf,
+            nuint size);
+    }
+}

--- a/src/Interop/Interop.projitems
+++ b/src/Interop/Interop.projitems
@@ -19,6 +19,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Interop.Pwhash.Argon2i.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop.Pwhash.Argon2id.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop.Pwhash.Scrypt.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Interop.Random.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop.Scalarmult.X25519.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop.SecretBox.XSalsa20Poly1305.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop.SecureMemoryHandle.cs" />

--- a/src/Interop/Interop.projitems
+++ b/src/Interop/Interop.projitems
@@ -27,6 +27,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Interop.Stream.ChaCha20.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop.Utils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interop.Version.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)NsecModuleInitializer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)Interop.yaml" />

--- a/src/Interop/NsecModuleInitializer.cs
+++ b/src/Interop/NsecModuleInitializer.cs
@@ -1,0 +1,50 @@
+﻿#nullable enable
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#if NETSTANDARD2_0
+
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class ModuleInitializerAttribute : Attribute
+    {
+    }
+}
+
+internal static class NsecModuleInitializer
+{
+    [ModuleInitializer]
+    internal static void Init()
+    {
+        if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            && RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework")))
+        {
+            return;
+        }
+
+        var path = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
+
+        if (!File.Exists(Path.Combine(path, "libsodium.dll")))
+        {
+            path = IntPtr.Size == 8
+                ? Path.Combine(path, "runtimes", "win-x64", "native")
+                : Path.Combine(path, "runtimes", "win-x86", "native");
+        }
+
+        var dllPath = Path.Combine(path, "libsodium.dll");
+        if (File.Exists(dllPath))
+        {
+            LoadLibrary(dllPath);
+        }
+
+        [DllImport("Kernel32.dll")]
+        static extern IntPtr LoadLibrary(string path);
+
+    }
+}
+
+#endif

--- a/tests/Base/StreamCipherAlgorithmTests.cs
+++ b/tests/Base/StreamCipherAlgorithmTests.cs
@@ -152,7 +152,7 @@ namespace NSec.Tests.Base
             Assert.Equal(expected, actual);
 
             Utilities.RandomBytes.Slice(200, actual.Length).CopyTo(actual);
-            var incrCount = BitConverter.ToUInt32(Utilities.RandomBytes.Slice(0, 4));
+            var incrCount = BitConverter.ToUInt32(Utilities.RandomBytes.Slice(0, 4).ToArray(), 0);
             a.XOrIC(k, n, b, expected, incrCount);
             a.XOrIC(k, n, b, actual, incrCount);
             Assert.Equal(expected, actual);
@@ -186,7 +186,7 @@ namespace NSec.Tests.Base
             a.XOr(k, n, plaintext, actual);
             Assert.Equal(expected, actual);
 
-            var incrCount = BitConverter.ToUInt32(Utilities.RandomBytes.Slice(0, 4));
+            var incrCount = BitConverter.ToUInt32(Utilities.RandomBytes.Slice(0, 4).ToArray(), 0);
             a.XOrIC(k, n, actual.AsSpan(0, L), expected, incrCount);
             a.XOrIC(k, n, actual.AsSpan(0, L), actual, incrCount);
             Assert.Equal(expected, actual);
@@ -207,7 +207,7 @@ namespace NSec.Tests.Base
             a.XOr(k, n, actual.AsSpan(0, L), actual);
             Assert.Equal(expected, actual);
 
-            var incrCount = BitConverter.ToUInt32(Utilities.RandomBytes.Slice(0, 4));
+            var incrCount = BitConverter.ToUInt32(Utilities.RandomBytes.Slice(0, 4).ToArray(), 0);
             a.XOrIC(k, n, actual.AsSpan(0, L), expected, incrCount);
             a.XOrIC(k, n, actual.AsSpan(0, L), actual, incrCount);
             Assert.Equal(expected, actual);

--- a/tests/Registry.cs
+++ b/tests/Registry.cs
@@ -74,7 +74,9 @@ namespace NSec.Tests
             new Argon2i(new Argon2Parameters { DegreeOfParallelism = 1, MemorySize = 1 << 12, NumberOfPasses = 3 }),
             PasswordBasedKeyDerivationAlgorithm.Argon2id(new Argon2Parameters { DegreeOfParallelism = 1, MemorySize = 1 << 12, NumberOfPasses = 3 }),
             PasswordBasedKeyDerivationAlgorithm.Scrypt(new ScryptParameters { Cost = 1 << 11, BlockSize = 5, Parallelization = 1 }),
+            #if NET5_0_OR_GREATER
             new Pbkdf2HmacSha256(new Pbkdf2Parameters { IterationCount = 10 }),
+            #endif
         };
 
         public static readonly TheoryData<SignatureAlgorithm> SignatureAlgorithms = new()

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -13,8 +13,9 @@
   <PropertyGroup>
     <NoWarn>0618;IDE0060;$(NoWarn)</NoWarn>
   </PropertyGroup>
-
+  
   <ItemGroup>
+    <PackageReference Include="libsodium" Version="[1.0.18.2,1.0.19)" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
@@ -28,4 +29,19 @@
     <ProjectReference Include="..\src\Experimental\NSec.Experimental.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="$(Pkglibsodium)\runtimes\win-x86\native\libsodium.dll">
+      <Link>runtimes\win-x86\native\libsodium.dll</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="$(Pkglibsodium)\runtimes\win-x64\native\libsodium.dll">
+      <Link>runtimes\win-x64\native\libsodium.dll</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+  
 </Project>

--- a/tests/Tests.csproj.orig
+++ b/tests/Tests.csproj.orig
@@ -1,7 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net48</TargetFrameworks>
+<<<<<<< HEAD
+    <TargetFrameworks>net6.0</TargetFrameworks>
+=======
+    <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
+>>>>>>> f540a7c (Add back netstandard2.0 support)
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/Utilities.cs
+++ b/tests/Utilities.cs
@@ -24,7 +24,7 @@ namespace NSec.Tests
             return array;
         }
 
-        public static byte[] Substring(this byte[] array, Range range) => array.AsSpan(range).ToArray();
+        public static byte[] Substring(this byte[] array, Range range) => array.AsSpan(range.Start.Value, range.End.Value - range.Start.Value).ToArray();
 
         #region Random Bytes
 


### PR DESCRIPTION
Yesterday I could not update this NuGet, it was very annoying. I quickly added polyfills to the released tag. Today there are some other changes that make it more complicated, but the base idea is simple.

I haven't heard that .NET 4.8 reached end of life, so dropping support for netstandard2.0 looks somewhat lazy.

Could you probably split the library into 1-to-1 .NET friendly wrapper over LibSodium and all the rest? Or just add `#if-defs` to stuff that is hard to do in netstandard2.0?